### PR TITLE
Add custom -1 screen

### DIFF
--- a/lawnchair/src/app/lawnchair/CustomMinusOneOverlay.kt
+++ b/lawnchair/src/app/lawnchair/CustomMinusOneOverlay.kt
@@ -1,0 +1,59 @@
+package app.lawnchair
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.core.view.isVisible
+import app.lawnchair.minusone.MinusOneScreen
+import com.android.launcher3.views.BaseDragLayer
+import com.android.systemui.plugins.shared.LauncherOverlayManager
+
+class CustomMinusOneOverlay(private val launcher: LawnchairLauncher) :
+    LauncherOverlayManager,
+    LauncherOverlayManager.LauncherOverlay {
+
+    private var callbacks: LauncherOverlayCallbacks? = null
+    private val overlayView: ComposeView = ComposeView(launcher).apply {
+        setContent { MinusOneScreen() }
+        visibility = View.GONE
+    }
+
+    init {
+        launcher.dragLayer.addView(
+            overlayView,
+            BaseDragLayer.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+    }
+
+    override fun onAttachedToWindow() {
+        overlayView.visibility = View.VISIBLE
+    }
+
+    override fun onDetachedFromWindow() {
+        overlayView.visibility = View.GONE
+    }
+
+    override fun onScrollInteractionBegin() {}
+
+    override fun onScrollInteractionEnd() {}
+
+    override fun onScrollChange(progress: Float, rtl: Boolean) {
+        val width = overlayView.width.toFloat()
+        val direction = if (rtl) 1 else -1
+        overlayView.translationX = width * (1 - progress) * direction
+        if (!overlayView.isVisible && progress > 0f) overlayView.visibility = View.VISIBLE
+        if (progress == 0f) overlayView.visibility = View.GONE
+        callbacks?.onOverlayScrollChanged(progress)
+    }
+
+    override fun setOverlayCallbacks(callbacks: LauncherOverlayCallbacks?) {
+        this.callbacks = callbacks
+    }
+
+    companion object {
+        fun minusOneAvailable(context: android.content.Context) = true
+    }
+}

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -33,7 +33,7 @@ import app.lawnchair.factory.LawnchairWidgetHolder
 import app.lawnchair.gestures.GestureController
 import app.lawnchair.gestures.VerticalSwipeTouchController
 import app.lawnchair.gestures.config.GestureHandlerConfig
-import app.lawnchair.nexuslauncher.OverlayCallbackImpl
+import app.lawnchair.CustomMinusOneOverlay
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.root.RootHelperManager
@@ -78,7 +78,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class LawnchairLauncher : QuickstepLauncher() {
-    private val defaultOverlay by unsafeLazy { OverlayCallbackImpl(this) }
+    private val defaultOverlay by unsafeLazy { CustomMinusOneOverlay(this) }
     private val prefs by unsafeLazy { PreferenceManager.getInstance(this) }
     private val preferenceManager2 by unsafeLazy { PreferenceManager2.getInstance(this) }
     private val insetsController by unsafeLazy { WindowInsetsControllerCompat(launcher.window, rootView) }
@@ -113,10 +113,6 @@ class LawnchairLauncher : QuickstepLauncher() {
         super.onCreate(savedInstanceState)
 
         prefs.launcherTheme.subscribeChanges(this, ::updateTheme)
-        prefs.feedProvider.subscribeChanges(this, defaultOverlay::reconnect)
-        preferenceManager2.enableFeed.get().distinctUntilChanged().onEach { enable ->
-            defaultOverlay.setEnableFeed(enable)
-        }.launchIn(scope = lifecycleScope)
 
         if (prefs.autoLaunchRoot.get()) {
             lifecycleScope.launch {

--- a/lawnchair/src/app/lawnchair/minusone/MinusOneScreen.kt
+++ b/lawnchair/src/app/lawnchair/minusone/MinusOneScreen.kt
@@ -1,0 +1,19 @@
+package app.lawnchair.minusone
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun MinusOneScreen() {
+    Surface(color = MaterialTheme.colorScheme.background, modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(text = "Custom -1 Screen", color = MaterialTheme.colorScheme.onBackground)
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import app.lawnchair.data.iconoverride.IconOverrideRepository
-import app.lawnchair.nexuslauncher.OverlayCallbackImpl
+import app.lawnchair.CustomMinusOneOverlay
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.preferences2.preferenceManager2
@@ -79,7 +79,7 @@ fun HomeScreenPreferences(
             HomeScreenTextColorPreference()
         }
         PreferenceGroup(heading = stringResource(id = R.string.minus_one)) {
-            val feedAvailable = OverlayCallbackImpl.minusOneAvailable(LocalContext.current)
+            val feedAvailable = CustomMinusOneOverlay.minusOneAvailable(LocalContext.current)
             val enableFeedAdapter = prefs2.enableFeed.getAdapter()
             SwitchPreference(
                 adapter = enableFeedAdapter,


### PR DESCRIPTION
## Summary
- implement a built-in minus one screen
- switch launcher to use the new overlay
- expose minus one screen availability to preferences

## Testing
- `./gradlew assembleDebug -x lint` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68674ad0d4b88333b8ad207529d1b119