### PR TITLE
Fix invisible custom minus-one overlay

### DIFF
--- a/lawnchair/src/app/lawnchair/CustomMinusOneOverlay.kt
+++ b/lawnchair/src/app/lawnchair/CustomMinusOneOverlay.kt
@@ -30,7 +30,8 @@ class CustomMinusOneOverlay(private val launcher: LawnchairLauncher) :
     }
 
     override fun onAttachedToWindow() {
-        overlayView.visibility = View.VISIBLE
+        // INVISIBLE keeps the view measured, ensuring smooth appearance when swiping
+        overlayView.visibility = View.INVISIBLE
     }
 
     override fun onDetachedFromWindow() {
@@ -46,7 +47,7 @@ class CustomMinusOneOverlay(private val launcher: LawnchairLauncher) :
         val direction = if (rtl) 1 else -1
         overlayView.translationX = width * (1 - progress) * direction
         if (!overlayView.isVisible && progress > 0f) overlayView.visibility = View.VISIBLE
-        if (progress == 0f) overlayView.visibility = View.GONE
+        if (progress == 0f) overlayView.visibility = View.INVISIBLE
         callbacks?.onOverlayScrollChanged(progress)
     }
 


### PR DESCRIPTION
## Summary
- ensure the custom minus-one overlay remains measured by using `INVISIBLE`
- keep the overlay measured during swipe progress

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6877306b4be0833397b4139948b6bb9c